### PR TITLE
Added a CW Plugin attribute to mark the mod as vanilla compatible.

### DIFF
--- a/MoreSettings.cs
+++ b/MoreSettings.cs
@@ -10,7 +10,8 @@ using MoreSettings.Settings;
 
 namespace MoreSettings
 {
-    [BepInPlugin("MoreSettings","More Settings","0.2.0")]
+    [ContentWarningPlugin("MoreSettings","0.2.1", true)]
+    [BepInPlugin("MoreSettings","More Settings","0.2.1")]
     public class MoreSettings : BaseUnityPlugin 
     {
         private Harmony harmony;


### PR DESCRIPTION
The game has a built in attribute that lets mods mark themselves as vanilla compatible so I've added that. Without the attribute the game will not let you use this mod in public lobbies.